### PR TITLE
Cut out google api and have it output to the console 

### DIFF
--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -18,7 +18,7 @@ import (
 type serviceWrapper struct {
 	context            context.Context
 	jiraClient         *jira.Jira
-	spreadSheetsHelper helper.SpreadSheetHelper
+	// spreadSheetsHelper helper.SpreadSheetHelper
 }
 
 var all bool
@@ -54,15 +54,15 @@ Example: jira-metrics sync --year 2021 [--all | --sprint-week 41-43]`,
 			return errors.Wrap(err, "error creating JIRA client")
 		}
 
-		googleSheetsSrv, err := googlesheets.NewService(ctx,
-			"credentials.json",
-			// scope for reading
-			// "https://www.googleapis.com/auth/spreadsheets.readonly",
-			// scope to edit only an specific sheet
-			// "https://www.googleapis.com/auth/drive.file",
-			// scope for writing all sheets
-			"https://www.googleapis.com/auth/spreadsheets",
-		)
+		// googleSheetsSrv, err := googlesheets.NewService(ctx,
+		// 	"credentials.json",
+		// 	// scope for reading
+		// 	// "https://www.googleapis.com/auth/spreadsheets.readonly",
+		// 	// scope to edit only an specific sheet
+		// 	// "https://www.googleapis.com/auth/drive.file",
+		// 	// scope for writing all sheets
+		// 	"https://www.googleapis.com/auth/spreadsheets",
+		// )
 
 		if err != nil {
 			return errors.Wrap(err, "error initializing Google Sheets service")
@@ -71,7 +71,7 @@ Example: jira-metrics sync --year 2021 [--all | --sprint-week 41-43]`,
 		sv = &serviceWrapper{
 			context:            ctx,
 			jiraClient:         jc,
-			spreadSheetsHelper: helper.NewSpreadSheetHelper(googleSheetsSrv),
+			// spreadSheetsHelper: helper.NewSpreadSheetHelper(googleSheetsSrv),
 		}
 
 		return nil
@@ -139,17 +139,17 @@ Example: jira-metrics sync --year 2021 [--all | --sprint-week 41-43]`,
 		}
 
 		// Format resetting
-		spreadSheetID := viper.GetString("GOOGLE_SPREADSHEET")
-		issuesGid := viper.GetInt64("GOOGLE_SPREADSHEET_TICKETS_GID")
-		sprintListGid := viper.GetInt64("GOOGLE_SPREADSHEET_SPRINTS_GID")
+		// spreadSheetID := viper.GetString("GOOGLE_SPREADSHEET")
+		// issuesGid := viper.GetInt64("GOOGLE_SPREADSHEET_TICKETS_GID")
+		// sprintListGid := viper.GetInt64("GOOGLE_SPREADSHEET_SPRINTS_GID")
 
-		if err := sv.resetIssuesFormat(spreadSheetID, issuesGid); err != nil {
-			return err
-		}
+		// if err := sv.resetIssuesFormat(spreadSheetID, issuesGid); err != nil {
+		// 	return err
+		// }
 
-		if err := sv.resetSprintListFormat(spreadSheetID, sprintListGid); err != nil {
-			return err
-		}
+		// if err := sv.resetSprintListFormat(spreadSheetID, sprintListGid); err != nil {
+		// 	return err
+		// }
 
 		fmt.Printf("ALL DONE!\n")
 		return nil
@@ -193,33 +193,39 @@ func (sv serviceWrapper) syncSprint(sprintID, sprintName string) error {
 
 	issuesHelper := helper.NewIssuesHelper(issuesSrv)
 
-	fmt.Printf("Processing report for %s...\n", sprintName)
+	fmt.Printf("Processing report for %s...\n\n", sprintName)
 
 	allIssues, err := issuesHelper.ProcessReport(*sprintReport)
 	if err != nil {
 		return errors.Wrap(err, "error processing Sprint report")
 	}
+	fmt.Printf("Because of issues with Google; To use this now copy and paste the lines to the respective tabs\nThen go to \"Data\" and then \"Split Text Into Columns\" and use a custom seperator which in this case is this character: '|'\n\n")
 
-	fmt.Printf("Writing issues for %s in Google Sheets...\n", sprintName)
+	fmt.Printf("All the issues for %s. \n\nCopy and append to the Issues Tab:\n\n", sprintName)
 
-	if _, err := sv.spreadSheetsHelper.Append(
-		sv.context,
-		viper.GetString("GOOGLE_SPREADSHEET"),
-		viper.GetString("GOOGLE_SPREADSHEET_TICKETS_WR"),
-		allIssues.Convert(),
-	); err != nil {
-		return errors.Wrap(err, "error writing issues in GoogleSheets")
-	}
+	// if _, err := sv.spreadSheetsHelper.Append(
+	// 	sv.context,
+	// 	viper.GetString("GOOGLE_SPREADSHEET"),
+	// 	viper.GetString("GOOGLE_SPREADSHEET_TICKETS_WR"),
+	// 	allIssues.Convert(),
+	// ); err != nil {
+	// 	return errors.Wrap(err, "error writing issues in GoogleSheets")
+	// }
 
-	fmt.Printf("Adding Sprint to list %s in Google Sheets...\n", sprintName)
+	// fmt.Printf("Adding Sprint to list %s in Google Sheets...\n\n", sprintName)
+	// fmt.Printf("%s", allIssues);
+	allIssues.Convert();
+	
+	// fmt.Printf("%s", )
 
-	var sprintRows googlesheets.GoogleSheetValues = [][]interface{}{
-		{sprintName, sprintID, helper.SimplifySprintName(sprintName)},
-	}
+	// var sprintRows googlesheets.GoogleSheetValues = [][]interface{}{
+	// 	{sprintName, sprintID, helper.SimplifySprintName(sprintName)},
+	// }
+	fmt.Printf("\nSprint Rows: Copy and append to the Sprint Tab:\n\n%v|%v|%v\n\n", sprintName, sprintID, helper.SimplifySprintName(sprintName))
 
-	if err := sv.addSprintsToList(sprintRows); err != nil {
-		return errors.Wrapf(err, "errors adding Sprint %s to list", sprintName)
-	}
+	// if err := sv.addSprintsToList(sprintRows); err != nil {
+	// 	return errors.Wrapf(err, "errors adding Sprint %s to list", sprintName)
+	// }
 
 	return nil
 }
@@ -229,14 +235,14 @@ func (sv serviceWrapper) addSprintsToList(sprintRows googlesheets.GoogleSheetVal
 
 	fmt.Printf("Adding Sprints to list in Google Sheets...\n")
 
-	if _, err := sv.spreadSheetsHelper.Append(
-		sv.context,
-		viper.GetString("GOOGLE_SPREADSHEET"),
-		viper.GetString("GOOGLE_SPREADSHEET_SPRINTS_WR"),
-		sprintRows,
-	); err != nil {
-		return errors.Wrap(err, "error adding Sprints to Sprint list Google Sheets")
-	}
+	// if _, err := sv.spreadSheetsHelper.Append(
+	// 	sv.context,
+	// 	viper.GetString("GOOGLE_SPREADSHEET"),
+	// 	viper.GetString("GOOGLE_SPREADSHEET_SPRINTS_WR"),
+	// 	sprintRows,
+	// ); err != nil {
+	// 	return errors.Wrap(err, "error adding Sprints to Sprint list Google Sheets")
+	// }
 
 	return nil
 }
@@ -245,9 +251,9 @@ func (sv serviceWrapper) addSprintsToList(sprintRows googlesheets.GoogleSheetVal
 func (sv serviceWrapper) resetIssuesFormat(spreadSheetID string, gid int64) error {
 	fmt.Printf("Resetting format for issues list in Google Sheets...\n")
 
-	if _, err := sv.spreadSheetsHelper.ResetFormat(sv.context, spreadSheetID, gid, 1, 0); err != nil {
-		return errors.Wrap(err, "error resetting issues format in Google Sheets")
-	}
+	// if _, err := sv.spreadSheetsHelper.ResetFormat(sv.context, spreadSheetID, gid, 1, 0); err != nil {
+	// 	return errors.Wrap(err, "error resetting issues format in Google Sheets")
+	// }
 	return nil
 }
 
@@ -255,8 +261,8 @@ func (sv serviceWrapper) resetIssuesFormat(spreadSheetID string, gid int64) erro
 func (sv serviceWrapper) resetSprintListFormat(spreadSheetID string, gid int64) error {
 	fmt.Printf("Resetting format for Sprint list in Google Sheets...\n")
 
-	if _, err := sv.spreadSheetsHelper.ResetFormat(sv.context, spreadSheetID, gid, 1, 0); err != nil {
-		return errors.Wrap(err, "error resetting Sprint list format in Google Sheets")
-	}
+	// if _, err := sv.spreadSheetsHelper.ResetFormat(sv.context, spreadSheetID, gid, 1, 0); err != nil {
+	// 	return errors.Wrap(err, "error resetting Sprint list format in Google Sheets")
+	// }
 	return nil
 }

--- a/pkg/googlesheets/sheet_row.go
+++ b/pkg/googlesheets/sheet_row.go
@@ -1,6 +1,9 @@
 package googlesheets
 
-import "reflect"
+import (
+	"fmt"
+	"reflect"
+)
 
 type MySheetRow struct {
 	Sprint       string `json:"Sprint"`
@@ -22,25 +25,35 @@ type GoogleSheetValues [][]interface{}
 
 func (m MySheetRowArray) Convert() GoogleSheetValues {
 
-	result := make(GoogleSheetValues, len(m))
+	// for key, value := range m {
+	// 	// fmt.Printf("\n brandon sValue: %d values: %s \n", key, value);
+	// }
 
-	i := 0
+	// result := make(GoogleSheetValues, len(m))
+
+	// i := 0
 	for _, s := range m {
 
 		// transforming the sheet struct in a generic interface array ([]interface{})
 		sValue := reflect.ValueOf(s)
 		values := make([]interface{}, sValue.NumField())
-
+		// fmt.Printf("\n brandon sValue: %s values: %s \n", sValue, values);
 		for j := 0; j < sValue.NumField(); j++ {
 			// copy struct field value into interface
+			if (j == sValue.NumField()-1){
+				fmt.Printf("%v\n", sValue.Field((j)))
+			} else {
+				fmt.Printf("%v|", sValue.Field((j)))
+			}
+
 			if sValue.Field(j).CanInterface() {
 				values[j] = sValue.Field(j).Interface()
 			}
 		}
 
-		result[i] = values
-		i++
+		// // result[i] = values
+		// i++
 	}
 
-	return result
+	return nil
 }

--- a/pkg/helper/issues_helper.go
+++ b/pkg/helper/issues_helper.go
@@ -6,7 +6,6 @@ import (
 	"net/url"
 	"path"
 	"regexp"
-	"strings"
 
 	"github.com/jvalecillos/jira-metrics/pkg/googlesheets"
 	"github.com/jvalecillos/jira-metrics/pkg/jira"
@@ -88,10 +87,10 @@ func (i IssuesHelper) generateRow(
 	row := googlesheets.MySheetRow{
 		Sprint:       SimplifySprintName(sprintName),
 		TicketNumber: j.Key,
-		Title:        j.Summary,
-		Link:         i.generateJiraLink(j.Key, j.Summary),
+		Title:        fmt.Sprintf("\"%s\"", j.Summary),
+		Link:         fmt.Sprintf("\"%s\"", i.generateJiraLink(j.Key, j.Summary)),
 	}
-
+	// fmt.Printf("%s", int(j.EstimateStatistic.StatFieldValue.value));
 	// If the ticket was added after starting the Sprint
 	if added {
 		// original estimation
@@ -132,9 +131,8 @@ func (i IssuesHelper) generateJiraLink(issueID, issueTitle string) string {
 	u.Path = path.Join(u.Path, issueBrowseSuffix, issueID)
 
 	return fmt.Sprintf(
-		"=HYPERLINK(\"%s\",\"%s\")",
+		"%s",
 		u.String(),
-		strings.TrimSpace(strings.ReplaceAll(issueTitle, "\"", "'")),
 	)
 }
 


### PR DESCRIPTION
The google API changed in how oauth is handled. I tried to fix google but it wasn't quite working.

So I adapted the code to output in a `|` separated text. This then can just be copied to the google sheet and then with the columns selected go to `Data` -> `Split text into columns` and in the drop down select custom and add `|`

```
➜  jira-metrics git:(master) ✗ go run main.go sync --project 1464 --year 2023
Using config file: /Users/brandondonato-long/jira-metrics/.jira-metrics.yaml
Fetching Sprints from project 1464...
Filtering Sprints from year 2023...
? Choose a Sprint: MN Sprint 2023-W02-W04
Processing report for MN Sprint 2023-W02-W04...

Because of issues with Google; To use this now copy and paste the lines to the respective tabs
Then go to "Data" and then "Split Text Into Columns" and use a custom seperator which in this case is this character: '|'

All the issues for MN Sprint 2023-W02-W04.

Copy and append to the Issues Tab:


2023-W02-04|iOS|MN-972|"(iOS) Flaky UI Test MegaAddonsMockedUITests.testHFMockMegaAddOns_whenSkippedState_validateAddOnScreen"|"https://hellofresh.atlassian.net/browse/MN-972"|0|0|0|0|0|0
2023-W02-04|Backend|MN-982|"[Backend] Enable Order Creation for addons in Process Orchestrator"|"https://hellofresh.atlassian.net/browse/MN-982"|1|0|0|1|0|1
2023-W02-04|iOS|MN-111|"[iOS][Mock test] Validate add-on  for the week after cut off "|"https://hellofresh.atlassian.net/browse/MN-111"|3|0|0|3|2|0
2023-W02-04|Android|MN-857|"[Android] Flaky AgeVerificationMockedTest Test"|"https://hellofresh.atlassian.net/browse/MN-857"|0|0|0|0|0|0
2023-W02-04|Product|MN-981|"[QA] Check and create Applanga keys for addon categories"|"https://hellofresh.atlassian.net/browse/MN-981"|1|0|0|1|1|0
2023-W02-04|Backend|MN-1028|"[Backend]BFF: Add FCS categories to '/menu' endpoint"|"https://hellofresh.atlassian.net/browse/MN-1028"|3|0|0|3|3|0
2023-W02-04|Android|MN-1051|"[Android] Create BBC Experiment,  RCS and feature toggle "|"https://hellofresh.atlassian.net/browse/MN-1051"|2|0|0|2|1|0
2023-W02-04|Android|MN-1085|"[Android] Creating the view for tab indicator subcategories bar(dinner) in View/Edit Mode of menu screen"|"https://hellofresh.atlassian.net/browse/MN-1085"|3|0|0|3|3|0
2023-W02-04|Android|MN-1093|"[Android] Featured category carousel: Creating the generic component for title, sub-title, "view all" link, lazy row of recipes in a carousel with browse all item"|"https://hellofresh.atlassian.net/browse/MN-1093"|5|0|0|5|5|0
2023-W02-04|Backend|MN-1141|"[Backend] Update preselection quantity and OneOff at the same time"|"https://hellofresh.atlassian.net/browse/MN-1141"|2|0|0|2|0|0
2023-W02-04|Web|MN-1167|"[Web] Create CategoryItemsGrid to show items from a certain category/sub category"|"https://hellofresh.atlassian.net/browse/MN-1167"|5|0|0|5|5|0
2023-W02-04|Backend|MN-1171|"[Backend] Create data model"|"https://hellofresh.atlassian.net/browse/MN-1171"|3|0|0|3|3|0
2023-W02-04|Backend|MN-1189|"[Backend] Enable regional filtering feature in UK "|"https://hellofresh.atlassian.net/browse/MN-1189"|0|0|0|0|1|0
2023-W02-04|Backend|MN-1202|"Post-Mortem for #in-21878-2301"|"https://hellofresh.atlassian.net/browse/MN-1202"|0|0|0|0|0|0
2023-W02-04|Backend|MN-1203|"[Backend] In IT user selection has to migrated for boxes menu slot 1 "|"https://hellofresh.atlassian.net/browse/MN-1203"|0|0|0|0|1|0
2023-W02-04|Backend|MN-1209|"Post-Mortem for #in-21916-2301 - [FR] Failed to fetch content in bulk for menu addon selection"|"https://hellofresh.atlassian.net/browse/MN-1209"|0|0|0|0|0|0
2023-W02-04|Android|MN-1214|"[Android] Skipped week - Detail text is red"|"https://hellofresh.atlassian.net/browse/MN-1214"|0|0|0|0|0|0

Sprint Rows: Copy and append to the Sprint Tab:

MN Sprint 2023-W02-W04|9052|2023-W02-04

ALL DONE!
```